### PR TITLE
Feat/mail send

### DIFF
--- a/src/main/java/com/avanade/decolatech/viajava/controller/AuthController.java
+++ b/src/main/java/com/avanade/decolatech/viajava/controller/AuthController.java
@@ -11,14 +11,13 @@ import com.avanade.decolatech.viajava.service.conta.AccountConfirmationService;
 import com.avanade.decolatech.viajava.service.conta.ReenviarLinkConfirmacaoContaService;
 import com.avanade.decolatech.viajava.utils.properties.ApplicationProperties;
 import jakarta.validation.Valid;
-import jakarta.validation.constraints.Email;
-import jakarta.validation.constraints.NotBlank;
+
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.authentication.AuthenticationManager;
 import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
 import org.springframework.security.core.Authentication;
-import org.springframework.validation.annotation.Validated;
+
 import org.springframework.web.bind.annotation.*;
 
 @RestController

--- a/src/main/java/com/avanade/decolatech/viajava/controller/AuthController.java
+++ b/src/main/java/com/avanade/decolatech/viajava/controller/AuthController.java
@@ -1,14 +1,12 @@
 package com.avanade.decolatech.viajava.controller;
 
-import com.avanade.decolatech.viajava.domain.dtos.request.ConfirmarContaRequest;
-import com.avanade.decolatech.viajava.domain.dtos.request.LoginRequest;
-import com.avanade.decolatech.viajava.domain.dtos.request.LoginResponse;
-import com.avanade.decolatech.viajava.domain.dtos.request.ReenviarLinkRequest;
+import com.avanade.decolatech.viajava.domain.dtos.request.*;
 import com.avanade.decolatech.viajava.domain.model.Usuario;
 import com.avanade.decolatech.viajava.service.auth.AuthService;
 
 import com.avanade.decolatech.viajava.service.conta.AccountConfirmationService;
 import com.avanade.decolatech.viajava.service.conta.ReenviarLinkConfirmacaoContaService;
+import com.avanade.decolatech.viajava.service.usuario.ForgotPasswordService;
 import com.avanade.decolatech.viajava.utils.properties.ApplicationProperties;
 import jakarta.validation.Valid;
 
@@ -28,13 +26,15 @@ public class AuthController {
     private final AccountConfirmationService accountConfirmationService;
     private final ReenviarLinkConfirmacaoContaService reenviarLinkConfirmacaoContaService;
     private final AuthenticationManager authenticationManager;
+    private final ForgotPasswordService forgotPasswordService;
     private final ApplicationProperties properties;
 
-    public AuthController(AuthService authService, AccountConfirmationService accountConfirmationService, ReenviarLinkConfirmacaoContaService reenviarLinkConfirmacaoContaService, AuthenticationManager authenticationManager, ApplicationProperties properties) {
+    public AuthController(AuthService authService, AccountConfirmationService accountConfirmationService, ReenviarLinkConfirmacaoContaService reenviarLinkConfirmacaoContaService, AuthenticationManager authenticationManager, ForgotPasswordService forgotPasswordService, ApplicationProperties properties) {
         this.authService = authService;
         this.accountConfirmationService = accountConfirmationService;
         this.reenviarLinkConfirmacaoContaService = reenviarLinkConfirmacaoContaService;
         this.authenticationManager = authenticationManager;
+        this.forgotPasswordService = forgotPasswordService;
         this.properties = properties;
     }
 
@@ -65,6 +65,22 @@ public class AuthController {
     @PostMapping("/signup/reenviar-link")
     public ResponseEntity<Void> reenviarLink(@RequestBody @Valid ReenviarLinkRequest request) {
         this.reenviarLinkConfirmacaoContaService.execute(request.getEmail());
+
+        return ResponseEntity.noContent().build();
+    }
+
+    @PostMapping("/signup/resetar-senha")
+    public ResponseEntity<Void> resetarSenha(@RequestBody @Valid ReenviarLinkRequest request) {
+        this.forgotPasswordService.enviarEmailRecuperarSenha(request.getEmail());
+
+        return ResponseEntity.noContent().build();
+    }
+
+    @PostMapping("/forgot-password")
+    public ResponseEntity<Void> confirmarResetSenha(
+            @RequestParam("token") String token,
+            @RequestBody @Valid ResetarSenhaRequest request) {
+        this.forgotPasswordService.alterarSenha(request, token);
 
         return ResponseEntity.noContent().build();
     }

--- a/src/main/java/com/avanade/decolatech/viajava/domain/dtos/request/ResetarSenhaRequest.java
+++ b/src/main/java/com/avanade/decolatech/viajava/domain/dtos/request/ResetarSenhaRequest.java
@@ -1,0 +1,23 @@
+package com.avanade.decolatech.viajava.domain.dtos.request;
+
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Size;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@NoArgsConstructor
+@AllArgsConstructor
+@Getter
+@Setter
+public class ResetarSenhaRequest {
+
+    @NotBlank
+    @Size(min = 8, message = "A senha deve ter pelo menos 8 caracteres")
+    private String novaSenha;
+
+    @NotBlank
+    @Size(min = 8, message = "A confirmação de senha deve ter pelo menos 8 caracteres")
+    private String novaSenhaConfirmacao;
+}

--- a/src/main/java/com/avanade/decolatech/viajava/service/usuario/ForgotPasswordService.java
+++ b/src/main/java/com/avanade/decolatech/viajava/service/usuario/ForgotPasswordService.java
@@ -1,0 +1,75 @@
+package com.avanade.decolatech.viajava.service.usuario;
+
+import com.avanade.decolatech.viajava.domain.dtos.request.ResetarSenhaRequest;
+import com.avanade.decolatech.viajava.domain.exception.BusinessException;
+import com.avanade.decolatech.viajava.domain.exception.LinkValidationException;
+import com.avanade.decolatech.viajava.domain.exception.ResourceNotFoundException;
+import com.avanade.decolatech.viajava.domain.repository.UsuarioRepository;
+import com.avanade.decolatech.viajava.service.email.EmailService;
+import com.avanade.decolatech.viajava.strategy.EmailType;
+import com.avanade.decolatech.viajava.utils.UsuarioExceptionMessages;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.security.oauth2.jwt.Jwt;
+import org.springframework.security.oauth2.jwt.JwtDecoder;
+import org.springframework.stereotype.Service;
+
+import java.time.Instant;
+
+@Service
+public class ForgotPasswordService {
+
+    private final UsuarioRepository usuarioRepository;
+    private final EmailService emailService;
+    private final JwtDecoder jwtDecoder;
+    private final PasswordEncoder passwordEncoder;
+
+    public ForgotPasswordService(UsuarioRepository usuarioRepository, EmailService emailService, JwtDecoder jwtDecoder, PasswordEncoder passwordEncoder) {
+        this.usuarioRepository = usuarioRepository;
+        this.emailService = emailService;
+        this.jwtDecoder = jwtDecoder;
+        this.passwordEncoder = passwordEncoder;
+    }
+
+    public void enviarEmailRecuperarSenha(String email) {
+        this.usuarioRepository.findByEmail(email).ifPresentOrElse(usuario -> {
+                    this.emailService.enviarEmail(usuario, EmailType.PASSWORD_RESET_EMAIL);
+                },
+
+                () -> {
+                    throw new ResourceNotFoundException(UsuarioExceptionMessages.USUARIO_NAO_EXISTE);
+                });
+    }
+
+    public void alterarSenha(ResetarSenhaRequest request, String token) {
+        String novaSenha = request.getNovaSenha();
+        String novaSenhaConfirmacao = request.getNovaSenhaConfirmacao();
+
+        if (!novaSenha.equals(novaSenhaConfirmacao)) {
+            throw new BusinessException(String.format("[%s alterarSenha] -  As senhas devem ser equivalentes.", ForgotPasswordService.class.getName()));
+        }
+
+        Jwt tokenDecodificado = this.jwtDecoder.decode(token);
+        String email = tokenDecodificado.getSubject();
+        String purpose = tokenDecodificado.getClaimAsString("purpose");
+        Instant expiracao = tokenDecodificado.getExpiresAt();
+
+        if (expiracao != null && expiracao.isBefore(Instant.now())) {
+            throw new LinkValidationException(String.format("[%s alterarSenha] -  O link de confirmação expirou.", ForgotPasswordService.class.getName()));
+        }
+
+        if (!purpose.equals("password_reset")) {
+            throw new LinkValidationException(String.format("[%s alterarSenha] -  Token Inválido para esta operação.", ForgotPasswordService.class.getName()));
+        }
+
+        this.usuarioRepository.findByEmail(email).ifPresentOrElse(usuario -> {
+            String novaSenhaHash = this.passwordEncoder.encode(novaSenha);
+            usuario.setSenha(novaSenhaHash);
+
+            this.usuarioRepository.save(usuario);
+        }, () -> {
+            throw new ResourceNotFoundException(UsuarioExceptionMessages.USUARIO_NAO_EXISTE);
+        });
+
+
+    }
+}

--- a/src/main/java/com/avanade/decolatech/viajava/strategy/impl/ForgotPasswordStrategy.java
+++ b/src/main/java/com/avanade/decolatech/viajava/strategy/impl/ForgotPasswordStrategy.java
@@ -45,7 +45,7 @@ public class ForgotPasswordStrategy implements EmailStrategy {
 
         email.setTo(usuario.getEmail());
         email.setSubject("[Conta Viajava] Recuperação de Senha");
-        email.setFrom("no-reply");
+        email.setFrom(new InternetAddress(this.properties.getMailUsername(), "no-reply"));
 
         final Context context = new Context(LocaleContextHolder.getLocale());
         context.setVariable("nome", usuario.getNome());
@@ -69,11 +69,11 @@ public class ForgotPasswordStrategy implements EmailStrategy {
                 .issuer("viajava-backend")
                 .subject(email)
                 .claim("purpose", "password_reset")
-                .expiresAt(Instant.now().plusSeconds(7200))
+                .expiresAt(Instant.now().plusSeconds(900))
                 .build();
 
         String hashedContent = this.jwtEncoder.encode(JwtEncoderParameters.from(claims)).getTokenValue();
 
-        return this.properties.getBaseUrl() + "/auth/forgot-password/confirmar-conta?token=" + hashedContent;
+        return this.properties.getBaseUrl() + "/auth/forgot-password?token=" + hashedContent;
     }
 }

--- a/src/main/resources/templates/password-recover.html
+++ b/src/main/resources/templates/password-recover.html
@@ -16,6 +16,7 @@
                         <p>Para confirmar esta solicitação, clique no link abaixo:</p>
                         <p><a th:href="${linkConfirmacao}" style="color: #1a73e8;">Alterar Senha</a></p>
                         <p>Se você não solicitou este e-mail, pode ignorá-lo com segurança.</p>
+                        <p><strong>⏰ Atenção:</strong> este link estará disponível por apenas <strong>15 minutos</strong> a partir do envio deste e-mail. Após esse período, será necessário solicitar um novo.</p>
                         <p style="margin-top: 30px;">Atenciosamente,<br>Equipe ViaJava</p>
                     </td>
                 </tr>


### PR DESCRIPTION
Esta PR tem por objetivo adicionar as mudanças referentes ao fluxo de reset de senha. Entre as mudanças adicionadas, estão:

- Adição do tempo de expiração do link no corpo do template do email que será enviado ao usuário que fizer o pedido de reset de senha, tornando mais claro o tempo de vida do token.
- Correção da url do token gerado durante o pedido de  reset de senha, sendo agora condizente com a url do método confirmarResetSenha da AuthController
- Adição do método responsável pela alteração da senha na ForgotPasswordService.
- Adição da DTO para validar a senha e a confirmação da senha passadas quando for feita a requisição para alteração de senha.