### PR TITLE
Feat/reviews para user admin e client

### DIFF
--- a/src/main/java/com/avanade/decolatech/viajava/config/security/SecurityConfig.java
+++ b/src/main/java/com/avanade/decolatech/viajava/config/security/SecurityConfig.java
@@ -68,12 +68,17 @@ public class SecurityConfig {
                         .requestMatchers(HttpMethod.POST,"/payments/webhook").permitAll()
                         .requestMatchers(HttpMethod.PATCH, "/users/reactivate").permitAll()
                         .requestMatchers(HttpMethod.POST, "/chat").permitAll()
+                        .requestMatchers(HttpMethod.GET,"/reviews/package/*").permitAll()
+                        .requestMatchers(HttpMethod.GET, "/reviews/package/*/stats").permitAll()
+
+
 
                         .requestMatchers(HttpMethod.GET, "/users/**").hasAnyRole("ADMIN", "CLIENT")
                         .requestMatchers(HttpMethod.PATCH, "/users/**").hasAnyRole("ADMIN", "CLIENT")
                         .requestMatchers(HttpMethod.DELETE, "/users/**").hasAnyRole("ADMIN", "CLIENT")
                         .requestMatchers("/bookings/**").hasAnyRole("ADMIN", "CLIENT")
                         .requestMatchers("/payments/**").hasAnyRole("CLIENT", "ADMIN")
+                        .requestMatchers(HttpMethod.POST, "/reviews").hasAnyRole("ADMIN", "CLIENT")
 
 
                         .requestMatchers(HttpMethod.POST, "/users/admin").hasRole("ADMIN")

--- a/src/main/java/com/avanade/decolatech/viajava/controller/GeminiChatController.java
+++ b/src/main/java/com/avanade/decolatech/viajava/controller/GeminiChatController.java
@@ -1,7 +1,7 @@
 package com.avanade.decolatech.viajava.controller;
 
-import com.avanade.decolatech.viajava.domain.dtos.request.GeminiChatRequest;
-import com.avanade.decolatech.viajava.domain.dtos.response.BotResponse;
+import com.avanade.decolatech.viajava.domain.dtos.request.geminiChat.GeminiChatRequest;
+import com.avanade.decolatech.viajava.domain.dtos.response.geminiChat.BotResponse;
 import com.avanade.decolatech.viajava.service.geminiChat.GeminiChatService;
 import jakarta.validation.Valid;
 import org.springframework.http.ResponseEntity;

--- a/src/main/java/com/avanade/decolatech/viajava/controller/ReviewController.java
+++ b/src/main/java/com/avanade/decolatech/viajava/controller/ReviewController.java
@@ -1,0 +1,57 @@
+package com.avanade.decolatech.viajava.controller;
+
+import com.avanade.decolatech.viajava.controller.docs.ReviewControllerSwagger;
+import com.avanade.decolatech.viajava.domain.dtos.request.review.ReviewRequest;
+import com.avanade.decolatech.viajava.domain.dtos.response.review.ReviewResponse;
+import com.avanade.decolatech.viajava.domain.dtos.response.review.ReviewStatsResponse;
+import com.avanade.decolatech.viajava.domain.model.User;
+import com.avanade.decolatech.viajava.service.review.CreateReviewService;
+import com.avanade.decolatech.viajava.service.review.GetReviewByPackageService;
+import com.avanade.decolatech.viajava.service.review.GetReviewStatsService;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
+import java.util.UUID;
+
+@RestController
+@RequestMapping("/reviews")
+@Tag(name = "Reviews", description = "Endpoints for creating and retrieving user reviews")
+public class ReviewController implements ReviewControllerSwagger {
+    private final CreateReviewService createReviewService;
+    private final GetReviewByPackageService getReviewByPackageService;
+    private final GetReviewStatsService getReviewStatsService;
+
+    public ReviewController(CreateReviewService createReviewService,
+                            GetReviewByPackageService getReviewByPackageService,
+                            GetReviewStatsService getReviewStatsService) {
+        this.createReviewService = createReviewService;
+        this.getReviewByPackageService = getReviewByPackageService;
+        this.getReviewStatsService = getReviewStatsService;
+    }
+
+    @PostMapping
+    public ResponseEntity<ReviewResponse> createReview(@Valid @RequestBody ReviewRequest request,
+                                                       @AuthenticationPrincipal User authenticatedUser) {
+
+        UUID userId = authenticatedUser.getId();
+        ReviewResponse response = createReviewService.execute(request, userId);
+        return new ResponseEntity<>(response, HttpStatus.CREATED);
+    }
+
+    @GetMapping("/package/{packageId}")
+    public ResponseEntity<List<ReviewResponse>> getReviewsByPackage(@PathVariable UUID packageId) {
+        List<ReviewResponse> reviews = getReviewByPackageService.execute(packageId);
+        return ResponseEntity.ok(reviews);
+    }
+
+    @GetMapping("/package/{packageId}/stats")
+    public ResponseEntity<ReviewStatsResponse> getReviewStatsByPackage(@PathVariable UUID packageId) {
+        ReviewStatsResponse stats = getReviewStatsService.execute(packageId);
+        return ResponseEntity.ok(stats);
+    }
+}

--- a/src/main/java/com/avanade/decolatech/viajava/controller/docs/ReviewControllerSwagger.java
+++ b/src/main/java/com/avanade/decolatech/viajava/controller/docs/ReviewControllerSwagger.java
@@ -1,0 +1,57 @@
+package com.avanade.decolatech.viajava.controller.docs;
+
+import com.avanade.decolatech.viajava.domain.dtos.request.review.ReviewRequest;
+import com.avanade.decolatech.viajava.domain.dtos.response.review.ReviewResponse;
+import com.avanade.decolatech.viajava.domain.dtos.response.review.ReviewStatsResponse;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.security.SecurityRequirement;
+import jakarta.validation.Valid;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestBody;
+
+import java.util.List;
+import java.util.UUID;
+
+public interface ReviewControllerSwagger {
+
+    @Operation(summary = "Create a new review",
+            description = "Allows an authenticated user to create a review for a confirmed booking they have made. The user must be the owner of the booking.",
+            security = @SecurityRequirement(name = "security"))
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "201", description = "Review created successfully",
+                    content = @Content(mediaType = "application/json", schema = @Schema(implementation = ReviewResponse.class))),
+            @ApiResponse(responseCode = "400", description = "Invalid input data provided", content = @Content),
+            @ApiResponse(responseCode = "403", description = "User not authorized to review this booking", content = @Content),
+            @ApiResponse(responseCode = "404", description = "Booking not found", content = @Content)
+    })
+    ResponseEntity<ReviewResponse> createReview(@Valid @RequestBody ReviewRequest request,
+                                                @Parameter(hidden = true) @AuthenticationPrincipal com.avanade.decolatech.viajava.domain.model.User authenticatedUser);
+
+    @Operation(summary = "Get reviews by package ID",
+            description = "Retrieves a list of all public reviews for a specific travel package.",
+            security = @SecurityRequirement(name = "security"))
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "200", description = "Successfully retrieved list of reviews",
+                    content = @Content(mediaType = "application/json", schema = @Schema(implementation = ReviewResponse.class))),
+            @ApiResponse(responseCode = "404", description = "Package not found or has no reviews", content = @Content)
+    })
+    ResponseEntity<List<ReviewResponse>> getReviewsByPackage(@PathVariable UUID packageId);
+
+    @Operation(summary = "Get review statistics by package ID",
+            description = "Retrieves aggregated statistics for a package's reviews, including average rating, total count, and a breakdown of ratings from 1 to 5.",
+            security = @SecurityRequirement(name = "security"))
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "200", description = "Successfully retrieved review statistics",
+                    content = @Content(mediaType = "application/json", schema = @Schema(implementation = ReviewStatsResponse.class))),
+            @ApiResponse(responseCode = "404", description = "Package not found", content = @Content)
+    })
+    ResponseEntity<ReviewStatsResponse> getReviewStatsByPackage(@PathVariable UUID packageId);
+
+}

--- a/src/main/java/com/avanade/decolatech/viajava/domain/dtos/request/geminiChat/GeminiChatHistoryRequest.java
+++ b/src/main/java/com/avanade/decolatech/viajava/domain/dtos/request/geminiChat/GeminiChatHistoryRequest.java
@@ -1,4 +1,4 @@
-package com.avanade.decolatech.viajava.domain.dtos.request;
+package com.avanade.decolatech.viajava.domain.dtos.request.geminiChat;
 
 public record GeminiChatHistoryRequest(String sender, String text) {
 

--- a/src/main/java/com/avanade/decolatech/viajava/domain/dtos/request/geminiChat/GeminiChatRequest.java
+++ b/src/main/java/com/avanade/decolatech/viajava/domain/dtos/request/geminiChat/GeminiChatRequest.java
@@ -1,4 +1,4 @@
-package com.avanade.decolatech.viajava.domain.dtos.request;
+package com.avanade.decolatech.viajava.domain.dtos.request.geminiChat;
 
 import java.util.List;
 

--- a/src/main/java/com/avanade/decolatech/viajava/domain/dtos/request/review/RatingCount.java
+++ b/src/main/java/com/avanade/decolatech/viajava/domain/dtos/request/review/RatingCount.java
@@ -1,0 +1,4 @@
+package com.avanade.decolatech.viajava.domain.dtos.request.review;
+
+public record RatingCount(Integer rating, Long count) {
+}

--- a/src/main/java/com/avanade/decolatech/viajava/domain/dtos/request/review/ReviewRequest.java
+++ b/src/main/java/com/avanade/decolatech/viajava/domain/dtos/request/review/ReviewRequest.java
@@ -1,0 +1,20 @@
+package com.avanade.decolatech.viajava.domain.dtos.request.review;
+
+import jakarta.validation.constraints.*;
+
+import java.util.UUID;
+
+public record ReviewRequest(
+
+        @NotNull
+        UUID bookingId,
+
+        @NotNull
+        @Min(value = 1, message = "A avaliação deve ser no mínimo 1.")
+        @Max(value = 5, message = "A avaliação deve ser no máximo 5.")
+        Integer rating,
+
+        @NotBlank
+        @Size(max = 1000, message = "O comentário não pode exceder 1000 caracteres.")
+        String comment
+) {}

--- a/src/main/java/com/avanade/decolatech/viajava/domain/dtos/response/booking/BookingResponse.java
+++ b/src/main/java/com/avanade/decolatech/viajava/domain/dtos/response/booking/BookingResponse.java
@@ -2,6 +2,9 @@ package com.avanade.decolatech.viajava.domain.dtos.response.booking;
 
 
 import com.avanade.decolatech.viajava.domain.dtos.response.traveler.TravelerResponse;
+import com.avanade.decolatech.viajava.utils.LocalDateSerializer;
+import com.fasterxml.jackson.annotation.JsonFormat;
+import com.fasterxml.jackson.databind.annotation.JsonSerialize;
 
 import java.math.BigDecimal;
 import java.time.LocalDate;
@@ -14,8 +17,14 @@ public record BookingResponse(
         UUID userId,
         UUID packageId,
         BigDecimal totalPrice,
+        String orderNumber,
+
+        @JsonFormat(pattern = "yyyy-MM-dd'T'HH:mm:ss")
         LocalDateTime bookingDate,
+
+        @JsonSerialize(using = LocalDateSerializer.class)
         LocalDate travelDate,
+
         String bookingStatus,
         List<TravelerResponse> travelers
 ) {}

--- a/src/main/java/com/avanade/decolatech/viajava/domain/dtos/response/geminiChat/BotResponse.java
+++ b/src/main/java/com/avanade/decolatech/viajava/domain/dtos/response/geminiChat/BotResponse.java
@@ -1,4 +1,4 @@
-package com.avanade.decolatech.viajava.domain.dtos.response;
+package com.avanade.decolatech.viajava.domain.dtos.response.geminiChat;
 
 import com.avanade.decolatech.viajava.domain.dtos.response.pacote.PackageResponse;
 

--- a/src/main/java/com/avanade/decolatech/viajava/domain/dtos/response/geminiChat/GeminiChatResponse.java
+++ b/src/main/java/com/avanade/decolatech/viajava/domain/dtos/response/geminiChat/GeminiChatResponse.java
@@ -1,4 +1,4 @@
-package com.avanade.decolatech.viajava.domain.dtos.response;
+package com.avanade.decolatech.viajava.domain.dtos.response.geminiChat;
 
 import java.util.List;
 

--- a/src/main/java/com/avanade/decolatech/viajava/domain/dtos/response/review/ReviewResponse.java
+++ b/src/main/java/com/avanade/decolatech/viajava/domain/dtos/response/review/ReviewResponse.java
@@ -1,0 +1,16 @@
+package com.avanade.decolatech.viajava.domain.dtos.response.review;
+
+import com.fasterxml.jackson.annotation.JsonFormat;
+
+import java.time.LocalDate;
+import java.util.UUID;
+
+public record ReviewResponse(
+        UUID id,
+        Integer rating,
+        String comment,
+        @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd")
+        LocalDate reviewDate,
+        String userName,
+        String imageUrl
+) {}

--- a/src/main/java/com/avanade/decolatech/viajava/domain/dtos/response/review/ReviewStatsResponse.java
+++ b/src/main/java/com/avanade/decolatech/viajava/domain/dtos/response/review/ReviewStatsResponse.java
@@ -1,0 +1,10 @@
+package com.avanade.decolatech.viajava.domain.dtos.response.review;
+
+import java.util.Map;
+
+public record ReviewStatsResponse(
+        double averageRating,
+        long totalReviews,
+        Map<Integer, Long> ratingCounts
+) {}
+

--- a/src/main/java/com/avanade/decolatech/viajava/domain/dtos/response/traveler/TravelerResponse.java
+++ b/src/main/java/com/avanade/decolatech/viajava/domain/dtos/response/traveler/TravelerResponse.java
@@ -1,5 +1,8 @@
 package com.avanade.decolatech.viajava.domain.dtos.response.traveler;
 
+import com.avanade.decolatech.viajava.utils.LocalDateSerializer;
+import com.fasterxml.jackson.databind.annotation.JsonSerialize;
+
 import java.time.LocalDate;
 import java.util.UUID;
 
@@ -7,6 +10,8 @@ public record TravelerResponse(
         UUID id,
         String name,
         String document,
+
+        @JsonSerialize(using = LocalDateSerializer.class)
         LocalDate birthdate
 ) {}
 

--- a/src/main/java/com/avanade/decolatech/viajava/domain/mapper/ReviewMapper.java
+++ b/src/main/java/com/avanade/decolatech/viajava/domain/mapper/ReviewMapper.java
@@ -1,0 +1,19 @@
+package com.avanade.decolatech.viajava.domain.mapper;
+
+import com.avanade.decolatech.viajava.domain.dtos.response.review.ReviewResponse;
+import com.avanade.decolatech.viajava.domain.model.Review;
+import org.mapstruct.Mapper;
+import org.mapstruct.Mapping;
+
+import java.util.List;
+
+@Mapper(componentModel = "spring")
+public interface ReviewMapper {
+
+    @Mapping(source = "booking.user.name", target = "userName")
+    @Mapping(source = "booking.user.imageUrl", target = "imageUrl")
+    ReviewResponse toResponse(Review review);
+
+    List<ReviewResponse> toResponseList(List<Review> reviews);
+}
+

--- a/src/main/java/com/avanade/decolatech/viajava/domain/model/Review.java
+++ b/src/main/java/com/avanade/decolatech/viajava/domain/model/Review.java
@@ -1,0 +1,44 @@
+package com.avanade.decolatech.viajava.domain.model;
+
+import jakarta.persistence.*;
+import lombok.*;
+
+import java.time.LocalDate;
+import java.util.UUID;
+
+@Entity
+@Table(name = "TB_REVIEWS")
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+@ToString
+@Builder
+public class Review {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.AUTO)
+    @Column(name = "ID")
+    private UUID id;
+
+    @OneToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "BOOKING_ID", nullable = false)
+    private Booking booking;
+
+    @Column(name = "RATING")
+    private Integer rating;
+
+    @Column(name = "COMMENT", columnDefinition = "TEXT")
+    private String comment;
+
+    @Column(name = "REVIEW_DATE", updatable = false)
+    private LocalDate reviewDate;
+
+    @Column(name = "REMOVED")
+    private boolean removed = false;
+
+    @PrePersist
+    protected void onCreate() {
+        reviewDate = LocalDate.now();
+    }
+}

--- a/src/main/java/com/avanade/decolatech/viajava/domain/repository/ReviewRepository.java
+++ b/src/main/java/com/avanade/decolatech/viajava/domain/repository/ReviewRepository.java
@@ -1,0 +1,22 @@
+package com.avanade.decolatech.viajava.domain.repository;
+
+import com.avanade.decolatech.viajava.domain.dtos.request.review.RatingCount;
+import com.avanade.decolatech.viajava.domain.model.Review;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+import org.springframework.stereotype.Repository;
+
+import java.util.List;
+import java.util.UUID;
+
+@Repository
+public interface ReviewRepository extends JpaRepository<Review, UUID> {
+
+    @Query("SELECT r FROM Review r WHERE r.booking.travelPackage.id = :packageId")
+    List<Review> findByPackageId(@Param("packageId") UUID packageId);
+
+    @Query("SELECT new com.avanade.decolatech.viajava.domain.dtos.request.review.RatingCount(r.rating, COUNT(r)) " +
+            "FROM Review r WHERE r.booking.travelPackage.id = :packageId GROUP BY r.rating")
+    List<RatingCount> findRatingSummaryByPackageId(@Param("packageId") UUID packageId);
+}

--- a/src/main/java/com/avanade/decolatech/viajava/service/booking/CreateBookingService.java
+++ b/src/main/java/com/avanade/decolatech/viajava/service/booking/CreateBookingService.java
@@ -77,6 +77,12 @@ public class CreateBookingService {
         }
 
         LocalDate travelDate = request.getTravelDate();
+
+        LocalDate bookingDate = LocalDate.now();
+        if (!travelDate.isAfter(bookingDate)) {
+            throw new BusinessException("Travel date must be after the booking date.");
+        }
+
         if (travelDate.isBefore(travelPackage.getStartDate()) || travelDate.isAfter(travelPackage.getEndDate())) {
             throw new BusinessException("The travel date is outside the available period for this package.");
         }

--- a/src/main/java/com/avanade/decolatech/viajava/service/geminiChat/GeminiChatService.java
+++ b/src/main/java/com/avanade/decolatech/viajava/service/geminiChat/GeminiChatService.java
@@ -2,9 +2,9 @@ package com.avanade.decolatech.viajava.service.geminiChat;
 
 import com.avanade.decolatech.viajava.config.chatbot.GeminiApiClient;
 import com.avanade.decolatech.viajava.config.chatbot.PromptManager;
-import com.avanade.decolatech.viajava.domain.dtos.request.GeminiChatHistoryRequest;
-import com.avanade.decolatech.viajava.domain.dtos.response.BotResponse;
-import com.avanade.decolatech.viajava.domain.dtos.response.GeminiChatResponse;
+import com.avanade.decolatech.viajava.domain.dtos.request.geminiChat.GeminiChatHistoryRequest;
+import com.avanade.decolatech.viajava.domain.dtos.response.geminiChat.BotResponse;
+import com.avanade.decolatech.viajava.domain.dtos.response.geminiChat.GeminiChatResponse;
 import com.avanade.decolatech.viajava.domain.dtos.response.pacote.PackageResponse;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import org.springframework.stereotype.Service;

--- a/src/main/java/com/avanade/decolatech/viajava/service/review/CreateReviewService.java
+++ b/src/main/java/com/avanade/decolatech/viajava/service/review/CreateReviewService.java
@@ -1,0 +1,53 @@
+package com.avanade.decolatech.viajava.service.review;
+
+import com.avanade.decolatech.viajava.domain.dtos.request.review.ReviewRequest;
+import com.avanade.decolatech.viajava.domain.dtos.response.review.ReviewResponse;
+import com.avanade.decolatech.viajava.domain.exception.BusinessException;
+import com.avanade.decolatech.viajava.domain.mapper.ReviewMapper;
+import com.avanade.decolatech.viajava.domain.model.Booking;
+import com.avanade.decolatech.viajava.domain.model.Review;
+import com.avanade.decolatech.viajava.domain.model.enums.BookingStatus;
+import com.avanade.decolatech.viajava.domain.repository.BookingRepository;
+import com.avanade.decolatech.viajava.domain.repository.ReviewRepository;
+import jakarta.persistence.EntityNotFoundException;
+import jakarta.transaction.Transactional;
+import org.springframework.stereotype.Service;
+
+import java.util.UUID;
+
+@Service
+public class CreateReviewService {
+
+    private final ReviewRepository reviewRepository;
+    private final BookingRepository bookingRepository;
+    private final ReviewMapper reviewMapper;
+
+    public CreateReviewService(ReviewRepository reviewRepository, BookingRepository bookingRepository, ReviewMapper reviewMapper) {
+        this.reviewRepository = reviewRepository;
+        this.bookingRepository = bookingRepository;
+        this.reviewMapper = reviewMapper;
+    }
+
+    @Transactional
+    public ReviewResponse execute(ReviewRequest request, UUID authenticatedUserId) {
+        Booking booking = bookingRepository.findById(request.bookingId())
+                .orElseThrow(() -> new EntityNotFoundException("Reserva não encontrada."));
+
+        if (!booking.getUser().getId().equals(authenticatedUserId)) {
+            throw new BusinessException("Você não tem permissão para avaliar esta reserva.");
+        }
+
+        if (booking.getBookingStatus() != BookingStatus.CONFIRMED) {
+            throw new BusinessException("Só é possível avaliar reservas com status CONFIRMADO.");
+        }
+
+        Review review = Review.builder()
+                .booking(booking)
+                .rating(request.rating())
+                .comment(request.comment())
+                .build();
+
+        Review savedReview = reviewRepository.save(review);
+        return reviewMapper.toResponse(savedReview);
+    }
+}

--- a/src/main/java/com/avanade/decolatech/viajava/service/review/GetReviewByPackageService.java
+++ b/src/main/java/com/avanade/decolatech/viajava/service/review/GetReviewByPackageService.java
@@ -1,0 +1,29 @@
+package com.avanade.decolatech.viajava.service.review;
+
+import com.avanade.decolatech.viajava.domain.dtos.response.review.ReviewResponse;
+import com.avanade.decolatech.viajava.domain.mapper.ReviewMapper;
+import com.avanade.decolatech.viajava.domain.repository.ReviewRepository;
+import jakarta.transaction.Transactional;
+import org.springframework.stereotype.Service;
+
+import java.util.List;
+import java.util.UUID;
+
+@Service
+public class GetReviewByPackageService {
+
+    private final ReviewRepository reviewRepository;
+    private final ReviewMapper reviewMapper;
+
+    public GetReviewByPackageService(ReviewRepository reviewRepository, ReviewMapper reviewMapper) {
+        this.reviewRepository = reviewRepository;
+        this.reviewMapper = reviewMapper;
+    }
+
+    @Transactional
+    public List<ReviewResponse> execute(UUID packageId) {
+        var reviews = reviewRepository.findByPackageId(packageId);
+        return reviewMapper.toResponseList(reviews);
+    }
+
+}

--- a/src/main/java/com/avanade/decolatech/viajava/service/review/GetReviewStatsService.java
+++ b/src/main/java/com/avanade/decolatech/viajava/service/review/GetReviewStatsService.java
@@ -1,0 +1,49 @@
+package com.avanade.decolatech.viajava.service.review;
+
+import com.avanade.decolatech.viajava.domain.dtos.request.review.RatingCount;
+import com.avanade.decolatech.viajava.domain.dtos.response.review.ReviewStatsResponse;
+import com.avanade.decolatech.viajava.domain.repository.ReviewRepository;
+import jakarta.transaction.Transactional;
+import org.springframework.stereotype.Service;
+
+import java.util.List;
+import java.util.Map;
+import java.util.UUID;
+import java.util.function.Function;
+import java.util.stream.Collectors;
+import java.util.stream.IntStream;
+
+@Service
+public class GetReviewStatsService {
+    private final ReviewRepository reviewRepository;
+
+    public GetReviewStatsService(ReviewRepository reviewRepository) {
+        this.reviewRepository = reviewRepository;
+    }
+
+    @Transactional
+    public ReviewStatsResponse execute(UUID packageId) {
+        List<RatingCount> summary = reviewRepository.findRatingSummaryByPackageId(packageId);
+
+        if (summary.isEmpty()) {
+            return new ReviewStatsResponse(0.0, 0, createEmptyRatingMap());
+        }
+
+        long totalReviews = summary.stream().mapToLong(RatingCount::count).sum();
+        long weightedSum = summary.stream().mapToLong(s -> s.rating() * s.count()).sum();
+        double averageRating = (double) weightedSum / totalReviews;
+
+        Map<Integer, Long> ratingCounts = createEmptyRatingMap();
+        summary.forEach(s -> ratingCounts.put(s.rating(), s.count()));
+
+        double formattedAverage = Math.round(averageRating * 100.0) / 100.0;
+
+        return new ReviewStatsResponse(formattedAverage, totalReviews, ratingCounts);
+    }
+
+    private Map<Integer, Long> createEmptyRatingMap() {
+        return IntStream.rangeClosed(1, 5)
+                .boxed()
+                .collect(Collectors.toMap(Function.identity(), i -> 0L));
+    }
+}


### PR DESCRIPTION
## Fluxo de cadastro e exibição de avaliações para admin e client

- Criação de entity, dtos, repository, services e controller do fluxo de reviews;
- Em ReviewRepository foi criado duas queries: Uma para encontrar as reviews por id de package, e a outra para contabilizar a quantidade de cada "estrela" (ex.: em uma review, quantas vezes marcaram 3 estrelas);
- Service para criação de reviews em um pacote, apenas para o usuário que tiver uma reserva, nesse pacote,  com bookingStatus CONFIRMED (no caso, a compra aprovada).
- Service para retornar a lista pública de reviews por pacote, contendo: nome, foto, data, comentário e estrela;
- Service para mostrar o count de cada valor de estrela por pacote, e sua média ponderada.

OBS.: o relacionamento permanece OneToOne entre Reservas e  Avaliações, mas as Avaliações estarão na tela de pacotes, então faz sentido visual, e a nível de consulta/fluxo realizado, dizer que se trata de avaliações por pacotes, ao invés de avaliações por reservas (pois um mesmo pacote vai poder ter diferentes reservas, mas uma reserva será vicnulada a apenas um pacote). 

## Pendências
-Fluxo de reviews no painel admin