### PR TITLE
Feat/dashboard

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -61,6 +61,12 @@
 		</dependency>
 
 		<dependency>
+			<groupId>com.itextpdf</groupId>
+			<artifactId>html2pdf</artifactId>
+			<version>4.0.5</version>
+		</dependency>
+
+		<dependency>
 			<groupId>org.springdoc</groupId>
 			<artifactId>springdoc-openapi-starter-webmvc-ui</artifactId>
 			<version>2.8.5</version>

--- a/src/main/java/com/avanade/decolatech/viajava/config/security/SecurityConfig.java
+++ b/src/main/java/com/avanade/decolatech/viajava/config/security/SecurityConfig.java
@@ -63,6 +63,7 @@ public class SecurityConfig {
                         .requestMatchers(HttpMethod.POST, "/auth/**").permitAll()
                         .requestMatchers(HttpMethod.POST, "/users").permitAll()
                         .requestMatchers(HttpMethod.PATCH, "/users/role").hasRole("ADMIN")
+                        .requestMatchers("/dashboard/**").hasRole("ADMIN")
                         .requestMatchers(HttpMethod.PATCH, "/users/**").hasAnyRole("ADMIN", "CLIENT")
                         .requestMatchers(HttpMethod.DELETE, "/users").hasAnyRole("ADMIN", "CLIENT")
                         .requestMatchers(HttpMethod.GET, "/users/*/image").hasAnyRole("ADMIN", "CLIENT")

--- a/src/main/java/com/avanade/decolatech/viajava/controller/DashboardController.java
+++ b/src/main/java/com/avanade/decolatech/viajava/controller/DashboardController.java
@@ -1,0 +1,47 @@
+package com.avanade.decolatech.viajava.controller;
+
+import com.avanade.decolatech.viajava.controller.docs.DashboardControllerSwagger;
+import com.avanade.decolatech.viajava.domain.dtos.response.view.GeneralMetricsView;
+import com.avanade.decolatech.viajava.domain.dtos.response.view.MonthlyRevenueView;
+import com.avanade.decolatech.viajava.domain.dtos.response.view.PendingBookingClientsView;
+import com.avanade.decolatech.viajava.domain.dtos.response.view.PopularDestinationView;
+import com.avanade.decolatech.viajava.service.dashboard.DashboardService;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
+
+@RestController
+@RequestMapping("/dashboard")
+public class DashboardController implements DashboardControllerSwagger {
+
+    private final DashboardService dashboardService;
+
+    public DashboardController(DashboardService dashboardService) {
+        this.dashboardService = dashboardService;
+    }
+
+    @Override
+    @GetMapping("/general-metrics")
+    public ResponseEntity<GeneralMetricsView> getGeneralMetrics() {
+        return ResponseEntity.ok(dashboardService.getGeneralMetrics());
+    }
+
+    @Override
+    @GetMapping("/monthly-revenue")
+    public ResponseEntity<List<MonthlyRevenueView>> getMonthlyRevenue() {
+        return ResponseEntity.ok(dashboardService.getMonthlyRevenue());
+    }
+
+    @Override
+    @GetMapping("/popular-destinations")
+    public ResponseEntity<List<PopularDestinationView>> getPopularDestinations() {
+        return ResponseEntity.ok(dashboardService.getPopularDestinations());
+    }
+
+    @Override
+    @GetMapping("/pending-booking-clients")
+    public ResponseEntity<List<PendingBookingClientsView>> getPendingBookingClients() {
+        return ResponseEntity.ok(dashboardService.getPendingBookingClients());
+    }
+}

--- a/src/main/java/com/avanade/decolatech/viajava/controller/PaymentController.java
+++ b/src/main/java/com/avanade/decolatech/viajava/controller/PaymentController.java
@@ -1,5 +1,6 @@
 package com.avanade.decolatech.viajava.controller;
 
+import com.avanade.decolatech.viajava.controller.docs.PaymentControllerSwagger;
 import com.avanade.decolatech.viajava.domain.dtos.request.payment.CreatePaymentRequest;
 import com.avanade.decolatech.viajava.domain.dtos.request.payment.MercadoPagoNotification;
 import com.avanade.decolatech.viajava.domain.dtos.request.payment.ProcessPaymentNotificationRequest;
@@ -7,6 +8,7 @@ import com.avanade.decolatech.viajava.domain.dtos.response.payment.CreatePrefere
 import com.avanade.decolatech.viajava.domain.model.User;
 import com.avanade.decolatech.viajava.service.payment.CreatePreferenceService;
 import com.avanade.decolatech.viajava.service.payment.ProcessPaymentNotificationService;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -16,9 +18,10 @@ import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
 
+@Tag(name = "Payments", description = "Endpoints to process payment request and handle webhook notification processing")
 @RestController
 @RequestMapping("/payments")
-public class PaymentController {
+public class PaymentController implements PaymentControllerSwagger {
 
     private final CreatePreferenceService createPreferenceService;
     private final ProcessPaymentNotificationService notificationService;

--- a/src/main/java/com/avanade/decolatech/viajava/controller/docs/DashboardControllerSwagger.java
+++ b/src/main/java/com/avanade/decolatech/viajava/controller/docs/DashboardControllerSwagger.java
@@ -1,0 +1,71 @@
+package com.avanade.decolatech.viajava.controller.docs;
+
+import com.avanade.decolatech.viajava.domain.dtos.response.view.GeneralMetricsView;
+import com.avanade.decolatech.viajava.domain.dtos.response.view.MonthlyRevenueView;
+import com.avanade.decolatech.viajava.domain.dtos.response.view.PendingBookingClientsView;
+import com.avanade.decolatech.viajava.domain.dtos.response.view.PopularDestinationView;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.security.SecurityRequirement;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+
+import java.util.List;
+
+@Tag(name = "Dashboard", description = "Admin dashboard metrics and analytics")
+public interface DashboardControllerSwagger {
+
+    @Operation(
+            summary = "Get general metrics",
+            description = "Returns general platform statistics.",
+            security = @SecurityRequirement(name = "security")
+    )
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "200", description = "General metrics fetched successfully"),
+            @ApiResponse(responseCode = "401", description = "Unauthorized (missing or invalid token)"),
+            @ApiResponse(responseCode = "403", description = "Forbidden (user lacks ADMIN role)")
+    })
+    @GetMapping("/general-metrics")
+    ResponseEntity<GeneralMetricsView> getGeneralMetrics();
+
+    @Operation(
+            summary = "Get monthly revenue",
+            description = "Returns monthly revenue statistics.",
+            security = @SecurityRequirement(name = "security")
+    )
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "200", description = "Monthly revenue data fetched successfully"),
+            @ApiResponse(responseCode = "401", description = "Unauthorized (missing or invalid token)"),
+            @ApiResponse(responseCode = "403", description = "Forbidden (user lacks ADMIN role)")
+    })
+    @GetMapping("/monthly-revenue")
+    ResponseEntity<List<MonthlyRevenueView>> getMonthlyRevenue();
+
+    @Operation(
+            summary = "Get popular destinations",
+            description = "Returns a list of most popular destinations based on bookings.",
+            security = @SecurityRequirement(name = "security")
+    )
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "200", description = "Popular destinations fetched successfully"),
+            @ApiResponse(responseCode = "401", description = "Unauthorized (missing or invalid token)"),
+            @ApiResponse(responseCode = "403", description = "Forbidden (user lacks ADMIN role)")
+    })
+    @GetMapping("/popular-destinations")
+    ResponseEntity<List<PopularDestinationView>> getPopularDestinations();
+
+    @Operation(
+            summary = "Get clients with pending bookings",
+            description = "Returns clients with pending booking confirmations.",
+            security = @SecurityRequirement(name = "security")
+    )
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "200", description = "Pending booking clients fetched successfully"),
+            @ApiResponse(responseCode = "401", description = "Unauthorized (missing or invalid token)"),
+            @ApiResponse(responseCode = "403", description = "Forbidden (user lacks ADMIN role)")
+    })
+    @GetMapping("/pending-booking-clients")
+    ResponseEntity<List<PendingBookingClientsView>> getPendingBookingClients();
+}

--- a/src/main/java/com/avanade/decolatech/viajava/controller/docs/PaymentControllerSwagger.java
+++ b/src/main/java/com/avanade/decolatech/viajava/controller/docs/PaymentControllerSwagger.java
@@ -1,0 +1,63 @@
+package com.avanade.decolatech.viajava.controller.docs;
+
+import com.avanade.decolatech.viajava.domain.dtos.request.payment.CreatePaymentRequest;
+import com.avanade.decolatech.viajava.domain.dtos.request.payment.MercadoPagoNotification;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.security.SecurityRequirement;
+import jakarta.validation.Valid;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.*;
+
+public interface PaymentControllerSwagger {
+
+    @Operation(summary = "Create a payment preference",
+            description = "Creates a payment preference for a booking. Requires CLIENT role.",
+            security = @SecurityRequirement(name = "security"))
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "201", description = "Preference successfully created", content = @Content),
+            @ApiResponse(responseCode = "400", description = "Invalid request", content = @Content),
+            @ApiResponse(responseCode = "401", description = "Unauthorized", content = @Content),
+            @ApiResponse(responseCode = "403", description = "Forbidden", content = @Content)
+    })
+    ResponseEntity<Void> createPreference(
+            @RequestBody @Valid CreatePaymentRequest createPaymentRequest,
+            @Parameter(hidden = true) @AuthenticationPrincipal com.avanade.decolatech.viajava.domain.model.User user
+    );
+
+    @Operation(summary = "Payment success endpoint",
+            description = "Returns 'success' string. Accessible to all.")
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "200", description = "Success response", content = @Content(mediaType = "text/plain"))
+    })
+    String success();
+
+    @Operation(summary = "Payment fail endpoint",
+            description = "Returns 'fail' string. Accessible to all.")
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "200", description = "Fail response", content = @Content(mediaType = "text/plain"))
+    })
+    String fail();
+
+    @Operation(summary = "Payment pending endpoint",
+            description = "Returns 'pending' string. Accessible to all.")
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "200", description = "Pending response", content = @Content(mediaType = "text/plain"))
+    })
+    String pending();
+
+    @Operation(summary = "Handle MercadoPago payment webhook notification",
+            description = "Handles payment notifications from MercadoPago. Accessible without authentication.",
+            security = @SecurityRequirement(name = "none"))
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "200", description = "Notification processed or ignored", content = @Content),
+            @ApiResponse(responseCode = "400", description = "Invalid notification", content = @Content)
+    })
+    ResponseEntity<Void> handleGatewayNotification(
+            @RequestBody(required = false) MercadoPagoNotification notification
+    );
+}

--- a/src/main/java/com/avanade/decolatech/viajava/domain/dtos/response/view/GeneralMetricsView.java
+++ b/src/main/java/com/avanade/decolatech/viajava/domain/dtos/response/view/GeneralMetricsView.java
@@ -1,0 +1,11 @@
+package com.avanade.decolatech.viajava.domain.dtos.response.view;
+
+import java.math.BigDecimal;
+
+public interface GeneralMetricsView {
+    Long getActiveClients();
+    Long getConfirmedBookings();
+    BigDecimal getTotalRevenue();
+    Double getAvgRatings();
+    Long getAvailablePackages();
+}

--- a/src/main/java/com/avanade/decolatech/viajava/domain/dtos/response/view/MonthlyRevenueView.java
+++ b/src/main/java/com/avanade/decolatech/viajava/domain/dtos/response/view/MonthlyRevenueView.java
@@ -1,0 +1,10 @@
+package com.avanade.decolatech.viajava.domain.dtos.response.view;
+
+import java.math.BigDecimal;
+
+public interface MonthlyRevenueView {
+    Integer getYear();
+    Integer getMonth();
+    Long getBookingCount();
+    BigDecimal getRevenue();
+}

--- a/src/main/java/com/avanade/decolatech/viajava/domain/dtos/response/view/PendingBookingClientsView.java
+++ b/src/main/java/com/avanade/decolatech/viajava/domain/dtos/response/view/PendingBookingClientsView.java
@@ -1,0 +1,13 @@
+package com.avanade.decolatech.viajava.domain.dtos.response.view;
+
+import java.math.BigDecimal;
+import java.util.UUID;
+
+public interface PendingBookingClientsView {
+    String getClientName();
+    String getEmail();
+    String getPhone();
+    UUID getBookingId();
+    BigDecimal getTotalPrice();
+    BigDecimal getOutstandingBalance();
+}

--- a/src/main/java/com/avanade/decolatech/viajava/domain/dtos/response/view/PopularDestinationView.java
+++ b/src/main/java/com/avanade/decolatech/viajava/domain/dtos/response/view/PopularDestinationView.java
@@ -1,0 +1,9 @@
+package com.avanade.decolatech.viajava.domain.dtos.response.view;
+
+import java.math.BigDecimal;
+
+public interface PopularDestinationView {
+    String getDestination();
+    Long getBookings();
+    BigDecimal getRevenue();
+}

--- a/src/main/java/com/avanade/decolatech/viajava/domain/repository/BookingRepository.java
+++ b/src/main/java/com/avanade/decolatech/viajava/domain/repository/BookingRepository.java
@@ -4,6 +4,7 @@ import com.avanade.decolatech.viajava.domain.model.Booking;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
 
 import java.util.Optional;
 import java.util.UUID;
@@ -11,5 +12,9 @@ import java.util.UUID;
 public interface BookingRepository extends JpaRepository<Booking, UUID> {
 
     Page<Booking> findAllByUserId(UUID userId, Pageable pageable);
+
     Optional<Booking> findByOrderNumber(String orderNumber);
+
+    @Query("SELECT B FROM Booking B WHERE B.travelPackage.id = :packageId AND B.user.id = :userId")
+    Optional<Booking> findByPackageAndUserId(UUID packageId, UUID userId);
 }

--- a/src/main/java/com/avanade/decolatech/viajava/domain/repository/BookingRepository.java
+++ b/src/main/java/com/avanade/decolatech/viajava/domain/repository/BookingRepository.java
@@ -1,11 +1,14 @@
 package com.avanade.decolatech.viajava.domain.repository;
 
+import com.avanade.decolatech.viajava.domain.dtos.response.view.MonthlyRevenueView;
+import com.avanade.decolatech.viajava.domain.dtos.response.view.PendingBookingClientsView;
 import com.avanade.decolatech.viajava.domain.model.Booking;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 
+import java.util.List;
 import java.util.Optional;
 import java.util.UUID;
 
@@ -17,4 +20,24 @@ public interface BookingRepository extends JpaRepository<Booking, UUID> {
 
     @Query("SELECT B FROM Booking B WHERE B.travelPackage.id = :packageId AND B.user.id = :userId")
     Optional<Booking> findByPackageAndUserId(UUID packageId, UUID userId);
+
+    @Query(value = "SELECT " +
+            "YEAR AS year, " +
+            "MONTH AS month, " +
+            "BOOKING_COUNT AS bookingCount, " +
+            "REVENUE AS revenue " +
+            "FROM vw_monthly_revenue",
+            nativeQuery = true)
+    List<MonthlyRevenueView> findMonthlyRevenue();
+
+    @Query(value = "SELECT " +
+            "CLIENT_NAME AS clientName, " +
+            "EMAIL AS email, " +
+            "PHONE AS phone, " +
+            "BOOKING_ID AS bookingId, " +
+            "TOTAL_PRICE AS totalPrice, " +
+            "SALDO_DEVEDOR AS outstandingBalance " +
+            "FROM vw_pending_booking_clients",
+            nativeQuery = true)
+    List<PendingBookingClientsView> findPendingBookingClients();
 }

--- a/src/main/java/com/avanade/decolatech/viajava/domain/repository/PackageRepository.java
+++ b/src/main/java/com/avanade/decolatech/viajava/domain/repository/PackageRepository.java
@@ -1,11 +1,22 @@
 package com.avanade.decolatech.viajava.domain.repository;
 
+import com.avanade.decolatech.viajava.domain.dtos.response.view.PopularDestinationView;
 import com.avanade.decolatech.viajava.domain.model.Package;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.JpaSpecificationExecutor;
+import org.springframework.data.jpa.repository.Query;
 
+import java.util.List;
 import java.util.UUID;
 
 public interface PackageRepository extends JpaRepository<Package, UUID>, JpaSpecificationExecutor<Package> {
+
+    @Query(value = "SELECT " +
+            "DESTINATION AS destination, " +
+            "BOOKINGS AS bookings, " +
+            "REVENUE AS revenue " +
+            "FROM vw_popular_destinations",
+            nativeQuery = true)
+    List<PopularDestinationView> findPopularDestinations();
 
 }

--- a/src/main/java/com/avanade/decolatech/viajava/domain/repository/UserRepository.java
+++ b/src/main/java/com/avanade/decolatech/viajava/domain/repository/UserRepository.java
@@ -1,5 +1,6 @@
 package com.avanade.decolatech.viajava.domain.repository;
 
+import com.avanade.decolatech.viajava.domain.dtos.response.view.GeneralMetricsView;
 import com.avanade.decolatech.viajava.domain.dtos.response.payment.PaymentUserResponse;
 import com.avanade.decolatech.viajava.domain.model.User;
 import org.springframework.data.domain.Page;
@@ -31,4 +32,14 @@ public interface UserRepository extends JpaRepository<User, UUID>, JpaSpecificat
             "RIGHT JOIN PaymentEntity P ON B.id = P.booking.id " +
             "WHERE U.id = :userId")
     Page<PaymentUserResponse> findAllPaymentsByUserId(UUID userId, Pageable pageable);
+
+    @Query(value = "SELECT " +
+            "ACTIVE_CLIENTS AS activeClients, " +
+            "CONFIRMED_BOOKINGS AS confirmedBookings, " +
+            "TOTAL_REVENUE AS totalRevenue, " +
+            "AVG_RATINGS AS avgRatings, " +
+            "AVAILABLE_PACKAGES AS availablePackages " +
+            "FROM vw_general_metrics",
+            nativeQuery = true)
+    GeneralMetricsView getGeneralMetrics();
 }

--- a/src/main/java/com/avanade/decolatech/viajava/service/auth/AuthService.java
+++ b/src/main/java/com/avanade/decolatech/viajava/service/auth/AuthService.java
@@ -25,14 +25,13 @@ public class AuthService {
 
     public LoginResponse generateToken(User user) {
         var now = Instant.now();
-        var expiresIn = 300L;
 
         String roleName = user.getRole().getUserRole().name();
 
         var claims = JwtClaimsSet.builder()
                 .issuer("viajava-backend")
                 .subject(user.getId().toString())
-                .expiresAt(now.plusSeconds(expiresIn * 10 * 60))
+                .expiresAt(now.plusSeconds(3 * 60 * 60))
                 .claim("scope", roleName)
                 .claim("username", user.getEmail())
                 .build();
@@ -41,7 +40,7 @@ public class AuthService {
                 .encode(JwtEncoderParameters.from(claims))
                 .getTokenValue();
 
-        return new LoginResponse(token, 5L);
+        return new LoginResponse(token, 3L);
     }
 
     public String validateToken(String token) {

--- a/src/main/java/com/avanade/decolatech/viajava/service/dashboard/DashboardService.java
+++ b/src/main/java/com/avanade/decolatech/viajava/service/dashboard/DashboardService.java
@@ -1,0 +1,47 @@
+package com.avanade.decolatech.viajava.service.dashboard;
+
+import com.avanade.decolatech.viajava.domain.dtos.response.view.GeneralMetricsView;
+import com.avanade.decolatech.viajava.domain.dtos.response.view.MonthlyRevenueView;
+import com.avanade.decolatech.viajava.domain.dtos.response.view.PendingBookingClientsView;
+import com.avanade.decolatech.viajava.domain.dtos.response.view.PopularDestinationView;
+import com.avanade.decolatech.viajava.domain.repository.BookingRepository;
+import com.avanade.decolatech.viajava.domain.repository.PackageRepository;
+import com.avanade.decolatech.viajava.domain.repository.UserRepository;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+
+@Service
+public class DashboardService {
+
+    private final UserRepository userRepository;
+    private final BookingRepository bookingRepository;
+    private final PackageRepository packageRepository;
+
+    public DashboardService(UserRepository userRepository, BookingRepository bookingRepository, PackageRepository packageRepository) {
+        this.userRepository = userRepository;
+        this.bookingRepository = bookingRepository;
+        this.packageRepository = packageRepository;
+    }
+
+    @Transactional(readOnly = true)
+    public GeneralMetricsView getGeneralMetrics() {
+        return this.userRepository.getGeneralMetrics();
+    }
+
+    @Transactional(readOnly = true)
+    public List<MonthlyRevenueView> getMonthlyRevenue() {
+        return this.bookingRepository.findMonthlyRevenue();
+    }
+
+    @Transactional(readOnly = true)
+    public List<PopularDestinationView> getPopularDestinations() {
+        return this.packageRepository.findPopularDestinations();
+    }
+
+    @Transactional(readOnly = true)
+    public List<PendingBookingClientsView> getPendingBookingClients() {
+        return this.bookingRepository.findPendingBookingClients();
+    }
+}

--- a/src/main/java/com/avanade/decolatech/viajava/strategy/impl/PaymentConfirmationStrategy.java
+++ b/src/main/java/com/avanade/decolatech/viajava/strategy/impl/PaymentConfirmationStrategy.java
@@ -1,30 +1,45 @@
 package com.avanade.decolatech.viajava.strategy.impl;
 
-import com.avanade.decolatech.viajava.domain.model.User;
+import com.avanade.decolatech.viajava.domain.model.*;
+import com.avanade.decolatech.viajava.domain.model.Package;
 import com.avanade.decolatech.viajava.strategy.EmailStrategy;
 import com.avanade.decolatech.viajava.strategy.EmailType;
 import com.avanade.decolatech.viajava.utils.properties.ApplicationProperties;
+import com.itextpdf.html2pdf.HtmlConverter;
 import jakarta.mail.MessagingException;
 import jakarta.mail.internet.InternetAddress;
 import jakarta.mail.internet.MimeMessage;
-import org.springframework.context.i18n.LocaleContextHolder;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.core.io.ByteArrayResource;
 import org.springframework.mail.javamail.JavaMailSender;
 import org.springframework.mail.javamail.MimeMessageHelper;
 import org.springframework.stereotype.Service;
+import org.springframework.context.i18n.LocaleContextHolder;
 import org.thymeleaf.TemplateEngine;
 import org.thymeleaf.context.Context;
 
+import java.io.ByteArrayOutputStream;
 import java.io.UnsupportedEncodingException;
 import java.time.LocalDateTime;
+import java.time.format.DateTimeFormatter;
+import java.math.BigDecimal;
+import java.math.RoundingMode;
+import java.util.List;
+import java.util.UUID;
+import java.util.concurrent.ThreadLocalRandom;
 
 @Service
 public class PaymentConfirmationStrategy implements EmailStrategy {
 
+    private final Logger LOGGER = LoggerFactory.getLogger(PaymentConfirmationStrategy.class);
     private final JavaMailSender mailSender;
     private final ApplicationProperties properties;
     private final TemplateEngine templateEngine;
 
-    public PaymentConfirmationStrategy(JavaMailSender mailSender, ApplicationProperties properties, TemplateEngine templateEngine) {
+    public PaymentConfirmationStrategy(JavaMailSender mailSender,
+                                       ApplicationProperties properties,
+                                       TemplateEngine templateEngine) {
         this.mailSender = mailSender;
         this.properties = properties;
         this.templateEngine = templateEngine;
@@ -32,23 +47,85 @@ public class PaymentConfirmationStrategy implements EmailStrategy {
 
     @Override
     public void sendEmail(User user, Object... args) throws MessagingException, UnsupportedEncodingException {
-        final MimeMessage mimeMessage = this.mailSender.createMimeMessage();
-        final MimeMessageHelper email;
-        email = new MimeMessageHelper(mimeMessage, true, "UTF-8");
+        PaymentEntity payment = (PaymentEntity) args[0];
+        @SuppressWarnings("unchecked")
+        List<Traveler> travelers = (List<Traveler>) args[1];
+        @SuppressWarnings("unchecked")
+        List<Document> docs =  args[2] instanceof List<?> ? (List<Document>) args[2] : List.of();
+        Booking booking = (Booking) args[3];
+
+        String numeroPedido = booking.getOrderNumber();
+        BigDecimal totalReserva = booking.getTotalPrice();
+        BigDecimal totalPago = payment.getAmount();
+        BigDecimal valorUnitario = totalReserva.divide(BigDecimal.valueOf(travelers.size()), 2, RoundingMode.HALF_UP);
+        BigDecimal taxas = totalPago.subtract(totalReserva);
+        String numeroNotaFiscal = generateNotaFiscal();
+
+        MimeMessage mimeMessage = mailSender.createMimeMessage();
+        MimeMessageHelper email = new MimeMessageHelper(mimeMessage, true, "UTF-8");
 
         email.setTo(user.getEmail());
-        email.setSubject("[ViaJava] Confirmação de Pagamento");
-        email.setFrom(new InternetAddress(this.properties.getMailUsername(), "no-reply"));
+        email.setSubject("[ViaJava] Payment Confirmation");
+        email.setFrom(new InternetAddress(properties.getMailUsername(), "no-reply"));
 
-        final Context context = new Context(LocaleContextHolder.getLocale());
-        context.setVariable("nome", user.getName());
-        context.setVariable("dataAtual", LocalDateTime.now().getYear());
-        context.setVariable("linkReservas", this.properties.getFrontendBookingsUrl());
-
-        final String htmlContent = this.templateEngine.process("payment-confirmation", context);
+        Context emailBodyContext = new Context(LocaleContextHolder.getLocale());
+        emailBodyContext.setVariable("name", user.getName());
+        emailBodyContext.setVariable("reservationsLink", this.properties.getFrontendBookingsUrl());
+        emailBodyContext.setVariable("currentYear", LocalDateTime.now().getYear());
+        String htmlContent = templateEngine.process("payment-confirmation", emailBodyContext);
         email.setText(htmlContent, true);
 
-        this.mailSender.send(mimeMessage);
+        Context context = new Context(LocaleContextHolder.getLocale());
+        context.setVariable("empresa", this.createCompanyData());
+        context.setVariable("cliente", this.createCustomerData(user, docs));
+        context.setVariable("pagamento", payment);
+        context.setVariable("numeroPedido", numeroPedido);
+        context.setVariable("numeroNotaFiscal", numeroNotaFiscal);
+        context.setVariable("valorUnitario", valorUnitario);
+        context.setVariable("valorTotalReserva", totalReserva);
+        context.setVariable("valorTaxas", taxas);
+        context.setVariable("valorFinalPago", totalPago);
+        context.setVariable("currentYear", LocalDateTime.now().getYear());
+        context.setVariable("reservationsLink", this.properties.getFrontendBookingsUrl());
+
+        String pdfContent =  templateEngine.process("payment-receipt", context);
+
+        ByteArrayOutputStream outputStream = new ByteArrayOutputStream();
+        HtmlConverter.convertToPdf(pdfContent, outputStream);
+        email.addAttachment(
+                String.format("%s-%s.pdf",
+                        LocalDateTime.now().format(DateTimeFormatter.ofPattern("yyyyMMdd-HHmmss"))
+                        ,UUID.randomUUID()),
+                new ByteArrayResource(outputStream.toByteArray())
+        );
+
+        mailSender.send(mimeMessage);
+    }
+
+    private Object createCompanyData() {
+        return new Object() {
+            public String getNome() { return "ViaJava"; }
+            public String getCnpj() { return "12.345.678/0001-99"; }
+            public String getEndereco() { return "Rua Exemplo, 123 - Centro - São Paulo/SP - CEP: 01234-567"; }
+            public String getContato() { return "(11) 3333-4444 - corporate.viajava@gmail.com"; }
+        };
+    }
+
+    private Object createCustomerData(User user, List<Document> docs) {
+        String docNumber = docs.isEmpty() ? "000.000.000-00" : docs.getFirst().getDocumentNumber();
+        return new Object() {
+            public String getName() { return user.getName(); }
+            public String getDocumento() { return docNumber; }
+            public String getEmail() { return user.getEmail(); }
+            public String getTelefone() { return user.getPhone() != null ? user.getPhone() : "Não informado"; }
+        };
+    }
+
+    private String generateNotaFiscal() {
+        ThreadLocalRandom random = ThreadLocalRandom.current();
+        StringBuilder sb = new StringBuilder(44);
+        for (int i = 0; i < 44; i++) sb.append(random.nextInt(10));
+        return sb.toString();
     }
 
     @Override

--- a/src/main/resources/templates/payment-confirmation.html
+++ b/src/main/resources/templates/payment-confirmation.html
@@ -18,12 +18,12 @@
                 <tr>
                     <td style="padding: 30px;">
                         <h2 style="color:#f97316;">Pagamento Confirmado!</h2>
-                        <p>Olá <strong th:text="${nome}">Nome do Usuário</strong>,</p>
+                        <p>Olá <strong th:text="${name}">Nome do Usuário</strong>,</p>
                         <p>Temos ótimas notícias! O pagamento da sua reserva foi confirmado com sucesso.</p>
                         <p>Para verificar os detalhes desta e outras reservas, clique no link abaixo:</p>
 
                         <div style="text-align:center; margin: 30px 0;">
-                            <a th:href="${linkReservas}"
+                            <a th:href="${reservationsLink}"
                                style="background-color:#f97316; color:#ffffff; padding: 14px 28px; text-decoration:none; border-radius:6px; font-weight:bold;">
                                 Ver Detalhes da Reserva
                             </a>
@@ -37,7 +37,7 @@
 
                 <tr>
                     <td style="background-color:#f9f9f9; padding: 20px; text-align:center; font-size:12px; color:#999;">
-                        © <span th:text="${dataAtual}">2025</span> ViaJava. Todos os direitos reservados.<br>
+                        © <span th:text="${currentYear}">2025</span> ViaJava. Todos os direitos reservados.<br>
                         Esta é uma mensagem automática. Por favor, não responda este e-mail.
                     </td>
                 </tr>

--- a/src/main/resources/templates/payment-receipt.html
+++ b/src/main/resources/templates/payment-receipt.html
@@ -1,0 +1,84 @@
+<!DOCTYPE html>
+<html lang="pt-BR" xmlns:th="http://www.thymeleaf.org">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Comprovante de Pagamento</title>
+    <style>
+        * { margin: 0; padding: 0; box-sizing: border-box; }
+        body { font-family: 'Arial', sans-serif; font-size: 12px; line-height: 1.4; color: #000; background-color: #fff; padding: 20px; }
+        .container { max-width: 700px; margin: 0 auto; background: white; border: 2px solid #000; }
+        .header { text-align: center; padding: 20px; border-bottom: 2px solid #000; background-color: #f8f8f8; }
+        .header h1 { font-size: 18px; font-weight: bold; text-transform: uppercase; }
+        .header .subtitle { font-size: 16px; font-weight: bold; text-transform: uppercase; }
+        .document-info { text-align: center; padding: 15px; border-bottom: 1px solid #000; background-color: #f0f0f0; }
+        .document-info .doc-number { font-size: 14px; font-weight: bold; }
+        .content { padding: 20px; }
+        .section { margin-bottom: 20px; border: 1px solid #000; }
+        .section-header { background-color: #e8e8e8; padding: 8px 12px; border-bottom: 1px solid #000; font-weight: bold; font-size: 12px; text-transform: uppercase; }
+        .section-content { padding: 15px; }
+        .info-row { display: flex; margin-bottom: 8px; }
+        .info-label { font-weight: bold; width: 40%; text-transform: uppercase; }
+        .info-value { width: 60%; }
+        .valor-section { background-color: #f5f5f5; border: 2px solid #000; padding: 15px; text-align: center; margin: 20px 0; }
+        .valor-label { font-size: 12px; font-weight: bold; text-transform: uppercase; margin-bottom: 8px; }
+        .valor-amount { font-size: 24px; font-weight: bold; }
+        .status-section { text-align: center; padding: 10px; background-color: #e8f5e8; border: 2px solid #4a7c59; margin: 15px 0; }
+        .status-text { font-size: 14px; font-weight: bold; color: #2d5016; }
+        .footer { border-top: 2px solid #000; padding: 15px; text-align: center; background-color: #f8f8f8; font-size: 10px; }
+        .footer p { margin-bottom: 5px; }
+        .footer .importante { font-weight: bold; text-transform: uppercase; }
+        @media print { body { padding: 0; } .container { border: 2px solid #000; } }
+    </style>
+</head>
+<body>
+<div class="container">
+    <div class="header">
+        <h1 th:text="${empresa.nome}">EMPRESA LTDA</h1>
+        <div class="subtitle">Comprovante de Pagamento</div>
+    </div>
+
+    <div class="document-info">
+        <div class="doc-number">
+            DOCUMENTO Nº <span th:text="${numeroPedido}">000012345</span><br>
+            Nota Fiscal Nº <span th:text="${numeroNotaFiscal}">NF-001234</span>
+        </div>
+    </div>
+
+    <div class="status-section">
+        <div class="status-text">✓ PAGAMENTO CONFIRMADO</div>
+    </div>
+
+    <div class="content">
+        <div class="section">
+            <div class="section-header">Dados do Pagador</div>
+            <div class="section-content">
+                <div class="info-row"><div class="info-label">Nome:</div><div class="info-value" th:text="${cliente.name}">JOÃO SILVA SANTOS</div></div>
+                <div class="info-row"><div class="info-label">CPF/CNPJ:</div><div class="info-value" th:text="${cliente.documento}">123.456.789-00</div></div>
+                <div class="info-row"><div class="info-label">E-mail:</div><div class="info-value" th:text="${cliente.email}">joao.silva@email.com</div></div>
+                <div class="info-row"><div class="info-label">Telefone:</div><div class="info-value" th:text="${cliente.telefone}">(11) 99999-9999</div></div>
+            </div>
+        </div>
+
+        <div class="section">
+            <div class="section-header">Resumo Financeiro</div>
+            <div class="section-content">
+                <div class="info-row"><div class="info-label">V. Unitário:</div><div class="info-value" th:text="${#numbers.formatCurrency(valorUnitario)}">R$ 0,00</div></div>
+                <div class="info-row"><div class="info-label">Total Reserva:</div><div class="info-value" th:text="${#numbers.formatCurrency(valorTotalReserva)}">R$ 0,00</div></div>
+                <div class="info-row"><div class="info-label">Taxas:</div><div class="info-value" th:text="${#numbers.formatCurrency(valorTaxas)}">R$ 0,00</div></div>
+                <div class="info-row"><div class="info-label">Total Pago:</div><div class="info-value" th:text="${#numbers.formatCurrency(valorFinalPago)}">R$ 0,00</div></div>
+            </div>
+        </div>
+
+    </div>
+
+    <div class="footer">
+        <p class="importante">Este documento serve como comprovante de pagamento</p>
+        <p>Emitido em <span th:text="${#temporals.format(#temporals.createNow(), 'dd/MM/yyyy')} + ' às ' + ${#temporals.format(#temporals.createNow(), 'HH:mm:ss')}">01/08/2025 às 14:30:25</span></p>
+        <p th:if="${empresa.cnpj}" th:text="'CNPJ: ' + ${empresa.cnpj}">CNPJ: 12.345.678/0001-99</p>
+        <p th:if="${empresa.endereco}" th:text="${empresa.endereco}">Rua Exemplo, 123 - Centro - São Paulo/SP - CEP: 01234-567</p>
+        <p th:if="${empresa.contato}" th:text="'Contato: ' + ${empresa.contato}">(11) 3333-4444 - contato@empresa.com.br</p>
+    </div>
+</div>
+</body>
+</html>


### PR DESCRIPTION
Esta PR tem por objetivo adicionar as mudanças inerentes aos endpoints de GET para os dados que formarão os dashboards no frontend. Entre as adições, estão:

- Adição do endpoint de dashboard no security config de modo que só quem possui a role admin possa acessar as rotas protegidas
- Adição de interfaces com as anotações de documentação swagger tanto em Payments quanto na controller de dashboard.
- Adição dos métodos de consulta às views nos respectivos repositórios (UserRepository, BookingRepository e PackageRepository)
- Adição de interfaces responsáveis pela coleta dos dados das views armazenadas  no banco.
- Adição da DashboardService, que reúne os métodos de GET para cada view.
- Correção do tempo de expiração do token, que antes estava definido para durar 50 horas e agora foi corrigido para 3 horas.